### PR TITLE
Continuous suspend/resume notifications when host disconnected

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ lib_xud Change Log
 
   * RESOLVED:   Transmit timing fixes for U-series devices (introduced in sc_xud
     2.3.0)
+  * RESOLVED:   Continuous suspend/resume notifications when host disconnected
+                (introduced earlier as part of #11813)
 
 0.1.0
 -----

--- a/lib_xud/src/core/XUD_PowerSig.xc
+++ b/lib_xud/src/core/XUD_PowerSig.xc
@@ -362,84 +362,87 @@ int XUD_Suspend(XUD_PwrConfig pwrConfig)
 
 
 #elif defined ARCH_S || defined ARCH_X200 /* "Normal" polling suspend for L or S series */
-    t :> time;
-
-    // linestate is K on flag0 (inverted), J on flag1, SE0 on flag2
-    // note that if you look in device-attach function, high-speed chirps are opposite polarity
-    // that is chirp K on flag1 and chirp J on flag0 (inverted)
-    select
+    while (1)
     {
-        case (pwrConfig == XUD_PWR_SELF) => t when timerafter(time + SUSPEND_VBUS_POLL_TIMER_TICKS) :> void:
-            read_periph_word(USB_TILE_REF,  XS1_SU_PER_UIFM_CHANEND_NUM, XS1_SU_PER_UIFM_OTG_FLAGS_NUM, tmp);
-            if (!(tmp & (1 << XS1_SU_UIFM_OTG_FLAGS_SESSVLDB_SHIFT)))
-            {
-                // VBUS not valid
-                write_periph_word(USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM,  XS1_SU_PER_UIFM_FUNC_CONTROL_NUM, 4 /* OpMode 01 */);
-                return -1;
-            }
-            break;
-
-        // SE0, that looks like a reset
-        case flag2_port when pinseq(1) :> void:
-            t :> time;
-            select
-            {
-                case flag2_port when pinseq(0) :> void:
-                    // SE0 gone away, keep looping
-                    break;
-
-                case t when timerafter(time + T_FILTSE0) :> void:
-                    // consider 2.5ms a complete reset
-                    t :> time;
-                    t when timerafter(time + 250000) :> void;
-                    return 1;
-            }
-            break;
-
-        // K, start of resume
-        case flag0_port when pinseq(0) :> void: // inverted port
-            // TODO debounce?
-            unsafe chanend c;
-            asm("getr %0, 2" : "=r"(c)); // XS1_RES_TYPE_CHANEND=2 (no inline assembly immediate operands in xC)
-
-            if (g_curSpeed == XUD_SPEED_HS)
-            {
-                // start high-speed switch so it's completed as quickly as possible after end of resume is seen
-                unsafe {
-                    write_periph_word_two_part_start((chanend)c, USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM,  XS1_SU_PER_UIFM_FUNC_CONTROL_NUM, 0);
+        t :> time;
+    
+        // linestate is K on flag0 (inverted), J on flag1, SE0 on flag2
+        // note that if you look in device-attach function, high-speed chirps are opposite polarity
+        // that is chirp K on flag1 and chirp J on flag0 (inverted)
+        select
+        {
+            case (pwrConfig == XUD_PWR_SELF) => t when timerafter(time + SUSPEND_VBUS_POLL_TIMER_TICKS) :> void:
+                read_periph_word(USB_TILE_REF,  XS1_SU_PER_UIFM_CHANEND_NUM, XS1_SU_PER_UIFM_OTG_FLAGS_NUM, tmp);
+                if (!(tmp & (1 << XS1_SU_UIFM_OTG_FLAGS_SESSVLDB_SHIFT)))
+                {
+                    // VBUS not valid
+                    write_periph_word(USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM,  XS1_SU_PER_UIFM_FUNC_CONTROL_NUM, 4 /* OpMode 01 */);
+                    return -1;
                 }
-            }
-
-            select
-            {
-                // J, unexpected, return
-                case flag1_port when pinseq(1) :> void:
-                    // we have to complete the high-speed switch now
-                    // revert to full speed straight away - causes a blip on the bus
-                    // Note, switching to HS then back to FS is not ideal
-                    if (g_curSpeed == XUD_SPEED_HS)
-                    {
-                        unsafe {
-                            write_periph_word_two_part_end((chanend)c, 0);
-                        }
+                break;
+    
+            // SE0, that looks like a reset
+            case flag2_port when pinseq(1) :> void:
+                t :> time;
+                select
+                {
+                    case flag2_port when pinseq(0) :> void:
+                        // SE0 gone away, keep looping
+                        break;
+    
+                    case t when timerafter(time + T_FILTSE0) :> void:
+                        // consider 2.5ms a complete reset
+                        t :> time;
+                        t when timerafter(time + 250000) :> void;
+                        return 1;
+                }
+                break;
+    
+            // K, start of resume
+            case flag0_port when pinseq(0) :> void: // inverted port
+                // TODO debounce?
+                unsafe chanend c;
+                asm("getr %0, 2" : "=r"(c)); // XS1_RES_TYPE_CHANEND=2 (no inline assembly immediate operands in xC)
+    
+                if (g_curSpeed == XUD_SPEED_HS)
+                {
+                    // start high-speed switch so it's completed as quickly as possible after end of resume is seen
+                    unsafe {
+                        write_periph_word_two_part_start((chanend)c, USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM,  XS1_SU_PER_UIFM_FUNC_CONTROL_NUM, 0);
                     }
-                    write_periph_word(USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM, XS1_SU_PER_UIFM_FUNC_CONTROL_NUM, (1 << XS1_SU_UIFM_FUNC_CONTROL_XCVRSELECT_SHIFT) | (1 << XS1_SU_UIFM_FUNC_CONTROL_TERMSELECT_SHIFT));
-                    break;
-
-                // SE0, end of resume
-                case flag2_port when pinseq(1) :> void:
-                    if (g_curSpeed == XUD_SPEED_HS)
-                    {
-                        // complete the high-speed switch
-                        unsafe {
-                            write_periph_word_two_part_end((chanend)c, 0);
+                }
+    
+                select
+                {
+                    // J, unexpected, return
+                    case flag1_port when pinseq(1) :> void:
+                        // we have to complete the high-speed switch now
+                        // revert to full speed straight away - causes a blip on the bus
+                        // Note, switching to HS then back to FS is not ideal
+                        if (g_curSpeed == XUD_SPEED_HS)
+                        {
+                            unsafe {
+                                write_periph_word_two_part_end((chanend)c, 0);
+                            }
                         }
-                    }
-                    break;
-            }
-
-            asm("freer res[%0]" :: "r"(c));
-            return 0;
+                        write_periph_word(USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM, XS1_SU_PER_UIFM_FUNC_CONTROL_NUM, (1 << XS1_SU_UIFM_FUNC_CONTROL_XCVRSELECT_SHIFT) | (1 << XS1_SU_UIFM_FUNC_CONTROL_TERMSELECT_SHIFT));
+                        break;
+    
+                    // SE0, end of resume
+                    case flag2_port when pinseq(1) :> void:
+                        if (g_curSpeed == XUD_SPEED_HS)
+                        {
+                            // complete the high-speed switch
+                            unsafe {
+                                write_periph_word_two_part_end((chanend)c, 0);
+                            }
+                        }
+                        break;
+                }
+    
+                asm("freer res[%0]" :: "r"(c));
+                return 0;
+        }
     }
 #endif
 }


### PR DESCRIPTION
Introduced in 2.4.2 as part of bug fix 11813

Copy of xmos/sc_xud#3