### PR TITLE
Tmp disabling or RxError line handling

### DIFF
--- a/lib_xud/src/core/XUD_IoLoop.S
+++ b/lib_xud/src/core/XUD_IoLoop.S
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2018, XMOS Ltd, All rights reserved
+// Copyright (c) 2011-2020, XMOS Ltd, All rights reserved
 
 // XUD_LLD_IoLoop.S
 // Main USB interfacing loop


### PR DESCRIPTION
It appears some hosts are potentially using this to communicate a buffer under-run issue (see UTMI+ Spec, 3.3). There are still some issues with how the RxError interrupt tidies up which should be resolved. Also an issue exists where setting Iso endpoints not-ready before packet reception (normally an atomic operation) can be interrupted by RxError  leading to that EP never being able to be marked ready again for the lifetime of the program. Since we still get an EOP and a CRC failure this should have no huge downside. Note, since we do not check for CRC on Iso endpoints these bad, truncated packets will be received by the endpoint. However, this will likely produce a reduced gitch, in say audio, compared to dropping the whole packet.