### PR TITLE
Update test_xs3.xn for test_bulk_loopback

### DIFF
--- a/tests/test_bulk_loopback/test_xs3.xn
+++ b/tests/test_bulk_loopback/test_xs3.xn
@@ -9,7 +9,7 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-FB265">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="phoenix" SystemFrequency="500MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
           <Tile Number="0" Reference="tile[0]"/>
           <Tile Number="1" Reference="tile[1]"/>
         </Node>


### PR DESCRIPTION
Change the node's type from "phoenix" to "XS3-L16A-1024" and add missing node parameters.  The 'phoenix' type is not available in general.

Tracked by issue #75.