### PR TITLE
Revert changes in CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,8 @@ lib_xud Change Log
 1.1.2
 -----
 
-   * CHANGED: Pin Python package versions
-   * REMOVED: not necessary cpanfile
+  * CHANGED: Pin Python package versions
+  * REMOVED: not necessary cpanfile
 
 1.1.1
 -----


### PR DESCRIPTION
  - version 1.1.2 of lib_xud has already been released, so we shouldn't change the history of repo
  - the changes are causing failures in sw_xvf3510 Jenkins