### PR TITLE
Issue STALL even when EP is marked ready

### DIFF
--- a/lib_xud/src/core/included/XUD_Token_Out.S
+++ b/lib_xud/src/core/included/XUD_Token_Out.S
@@ -12,6 +12,13 @@
 .skip 0
 Pid_Out:
     #include "XUD_CrcAddrCheck.S"
+
+    ldaw       r11, dp[handshakeTable_OUT]       // Load handshake table
+    ldw        r11, r11[r10]
+    ldc        r3, USB_PIDn_STALL
+    eq         r3, r11, r3
+    bt         r3, XUD_TokenOut_BufferFull
+
     ldw        r3, r5[r10]                      // Load relevant EP pointer
     bf         r3, XUD_TokenOut_BufferFull
     ldw        r1, r3[3]                        // Load buffer from EP structure

--- a/lib_xud/src/core/included/XUD_Token_Out_DI.S
+++ b/lib_xud/src/core/included/XUD_Token_Out_DI.S
@@ -8,6 +8,13 @@
 .skip 0
 Pid_Out:
     #include "XUD_CrcAddrCheck.S"
+
+    ldaw       r11, dp[handshakeTable_OUT]       // Load handshake table
+   {ldw        r11, r11[r10]
+    ldc        r3, USB_PIDn_STALL}
+    eq         r3, r11, r3
+    bt         r3, XUD_TokenOut_BufferFull
+
     ldw        r3, r5[r10]                      // Load relevant EP pointer
     bf         r3, XUD_TokenOut_BufferFull
     ldw        r1, r3[3]                        // Load buffer from EP structure


### PR DESCRIPTION
If an OUT endpoint stalls and then subsequently waits for data, for
example with XUD_GetBuffer(), the endpoint will continue to respond with
STALL handshakes until the stall condition is cleared.

This fixes #58.

This also fixes my issue #129. I have also confirmed that the Tiny USB stack clears stalls when ClearFeature requests are received, so there is no longer a need to implement the type of workaround in aisrv - however, The USB_CLEAR_FEATURE case in USB_StandardRequests() will need to call XUD_ClearStallByAddr().
