### PR TITLE
Issue STALL even when EP is marked ready

### DIFF
--- a/lib_xud/src/core/included/XUD_Token_In_DI.S
+++ b/lib_xud/src/core/included/XUD_Token_In_DI.S
@@ -23,26 +23,35 @@
 // R1 : Valid Token Port
 // R0 : RXD
 .align FUNCTION_ALIGNMENT
-InNotReady:
-    ldw         r11, sp[STACK_EPTYPES_IN]
-    ldw         r11, r11[r10]                       // Load EP Type
-    bt          r11, XUD_IN_TxNak
-    ldc         r11, 0xc3                           // Create 0-length packet
-    outpw       res[TXD], r11, 24
-    #include "XUD_TokenJmp.S"
-
-XUD_IN_TxNak:                                       // Non-Iso
-    ldaw       r11, dp[handshakeTable_IN]           // Load handshake table
-    ldw        r11, r11[r10]                        // Load handshake PID
-    outpw     res[TXD], r11, 8
-    #include "XUD_TokenJmp.S"
-
-.align FUNCTION_ALIGNMENT
 Pid_In:
     #include "XUD_CrcAddrCheck.S"
-    ldaw       r3, r10[4]                           // R3 = R10 + 16
-    ldw        r4, r5[r3]                           // Load EP structure address
-    bf         r4, InNotReady                       // If 0 then not ready...
+    ldaw       r3,  r10[4]                          // R3 = R10 + 16
+    ldw        r4,  r5[r3]                          // Load EP structure address into R4
+
+
+    ldw        r11, sp[STACK_EPTYPES_IN]
+    ldw        r11, r11[r10]                        // Load EP Type into R11
+    bt         r11, In_NonIso                       // If the type is non-zero then it is not isochronous
+    bt         r4,  In_LoadPid                      // If the EP structure address is not 0, and the
+                                                    // EP type is iso, then we are ready to send.
+    ldc        r11, 0xc3                            // Otherwise, create 0-length packet
+    outpw      res[TXD], r11, 24
+    #include "XUD_TokenJmp.S"
+
+In_NonIso:
+    ldaw       r11, dp[handshakeTable_IN]           // Load handshake table
+    ldw        r11, r11[r10]                        // Load handshake PID into R11
+   {bf         r4,  In_TxHandshake                  // If the EP structure address is 0, and the EP type
+                                                    // is not iso, then send the PID from the handshake table.
+    ldc        r8,  USB_PIDn_STALL}                 // If the EP is ready, then compare the STALL PID
+    eq         r8,  r11, r8                         // with the PID in the handshake table.
+    bf         r8,  In_LoadPid                      // If it's not a STALL, then we are ready to send.
+                                                    // Otherwise, send the PID from the handshake table.
+    ldc r8, 0
+    ecallf r8
+In_TxHandshake:
+    outpw     res[TXD], r11, 8
+    #include "XUD_TokenJmp.S"
 
 In_LoadPid:
     ldw         r11, r4[4]                          // Load PID from structure

--- a/lib_xud/src/core/included/XUD_Token_In_DI.S
+++ b/lib_xud/src/core/included/XUD_Token_In_DI.S
@@ -47,8 +47,6 @@ In_NonIso:
     eq         r8,  r11, r8                         // with the PID in the handshake table.
     bf         r8,  In_LoadPid                      // If it's not a STALL, then we are ready to send.
                                                     // Otherwise, send the PID from the handshake table.
-    ldc r8, 0
-    ecallf r8
 In_TxHandshake:
     outpw     res[TXD], r11, 8
     #include "XUD_TokenJmp.S"

--- a/lib_xud/src/core/included/XUD_Token_Out.S
+++ b/lib_xud/src/core/included/XUD_Token_Out.S
@@ -12,7 +12,6 @@
 .skip 0
 Pid_Out:
     #include "XUD_CrcAddrCheck.S"
-
     ldw        r3, r5[r10]                      // Load relevant EP pointer
     bf         r3, XUD_TokenOut_BufferFull
     ldw        r1, r3[3]                        // Load buffer from EP structure

--- a/lib_xud/src/core/included/XUD_Token_Out.S
+++ b/lib_xud/src/core/included/XUD_Token_Out.S
@@ -13,12 +13,6 @@
 Pid_Out:
     #include "XUD_CrcAddrCheck.S"
 
-    ldaw       r11, dp[handshakeTable_OUT]       // Load handshake table
-    ldw        r11, r11[r10]
-    ldc        r3, USB_PIDn_STALL
-    eq         r3, r11, r3
-    bt         r3, XUD_TokenOut_BufferFull
-
     ldw        r3, r5[r10]                      // Load relevant EP pointer
     bf         r3, XUD_TokenOut_BufferFull
     ldw        r1, r3[3]                        // Load buffer from EP structure
@@ -84,18 +78,21 @@ DoOutNonIso:
 
 doRXDataReturn_NonIso:
     bf         r1, NextTokenAfterOut            // Check for bad crc
-    ldc        r11, USB_PIDn_ACK                // Data CRC good and EP not Iso: Send Ack
-    nop
-    nop
-    nop
-    nop
-    nop
+
+    ldaw       r6,  dp[handshakeTable_OUT]      // Load the handshake table.
+    ldw        r11, r6[r10]                     // Get the handshake PID for this EP
+    ldc        r1,  USB_PIDn_STALL              // as well as the STALL PID
+    eq         r1,  r11, r1                     // and compare them.
+    bt         r1,  XUD_TokenOut_Handshake      // If the handshake PID for this EP is STALL, then
+                                                // go and send the handshake without clearing ready
+                                                // or communicating back to the application that
+                                                // the packet has been received.
+
+    ldc        r11, USB_PIDn_ACK                // Data CRC good, EP not Iso, and EP not halted: Send Ack
     outpw      res[TXD], r11, 8
     syncr      res[TXD]
 
 StoreTailDataOut:
-    //shr        r8, r8, 3                      // r8: number of tail bits, convert to bytes
-                                                // This is now done on the other side
     ldc        r11, 0
     stw        r11, r5[r10]                     // Clear ready
     ldw        r11, r3[1]                       // Load EP chanend
@@ -145,15 +142,13 @@ XUD_TokenOut_WaitForPacketEnd:                  // Wait for end of data then sen
 #endif
 
   // LOAD HANDSHAKE PID or STALL
-  ldaw       r5, dp[handshakeTable_OUT]         // Load handshake table
-  ldw        r11, r5[r10]
-  //ldc       r11, 0x5a
+  ldaw       r6, dp[handshakeTable_OUT]         // Load handshake table
+XUD_TokenOut_Handshake:
+  ldw        r11, r6[r10]
   outpw     res[TXD], r11, 8
   syncr     res[TXD]
 
 PrimaryBufferFull_NoNak:
-  //endin     r11, res[RXD]
-  //in        r11, res[RXD]
   setc      res[RXD], XS1_SETC_RUN_CLRBUF
   bu        NextToken
 

--- a/lib_xud/src/core/included/XUD_Token_Out.S
+++ b/lib_xud/src/core/included/XUD_Token_Out.S
@@ -12,6 +12,13 @@
 .skip 0
 Pid_Out:
     #include "XUD_CrcAddrCheck.S"
+
+    ldaw       r11, dp[handshakeTable_OUT]       // Load handshake table
+    ldw        r11, r11[r10]
+    ldc        r3, USB_PIDn_STALL
+    eq         r3, r11, r3
+    bt         r3, XUD_TokenOut_BufferFull
+
     ldw        r3, r5[r10]                      // Load relevant EP pointer
     bf         r3, XUD_TokenOut_BufferFull
     ldw        r1, r3[3]                        // Load buffer from EP structure

--- a/lib_xud/src/core/included/XUD_Token_Out_DI.S
+++ b/lib_xud/src/core/included/XUD_Token_Out_DI.S
@@ -8,7 +8,6 @@
 .skip 0
 Pid_Out:
     #include "XUD_CrcAddrCheck.S"
-
     ldw        r3, r5[r10]                      // Load relevant EP pointer
     bf         r3, XUD_TokenOut_BufferFull
     ldw        r1, r3[3]                        // Load buffer from EP structure

--- a/lib_xud/src/core/included/XUD_Token_Out_DI.S
+++ b/lib_xud/src/core/included/XUD_Token_Out_DI.S
@@ -8,6 +8,13 @@
 .skip 0
 Pid_Out:
     #include "XUD_CrcAddrCheck.S"
+
+    ldaw       r11, dp[handshakeTable_OUT]       // Load handshake table
+   {ldw        r11, r11[r10]
+    ldc        r3, USB_PIDn_STALL}
+    eq         r3, r11, r3
+    bt         r3, XUD_TokenOut_BufferFull
+
     ldw        r3, r5[r10]                      // Load relevant EP pointer
     bf         r3, XUD_TokenOut_BufferFull
     ldw        r1, r3[3]                        // Load buffer from EP structure

--- a/lib_xud/src/core/included/XUD_Token_Out_DI.S
+++ b/lib_xud/src/core/included/XUD_Token_Out_DI.S
@@ -9,12 +9,6 @@
 Pid_Out:
     #include "XUD_CrcAddrCheck.S"
 
-    ldaw       r11, dp[handshakeTable_OUT]       // Load handshake table
-   {ldw        r11, r11[r10]
-    ldc        r3, USB_PIDn_STALL}
-    eq         r3, r11, r3
-    bt         r3, XUD_TokenOut_BufferFull
-
     ldw        r3, r5[r10]                      // Load relevant EP pointer
     bf         r3, XUD_TokenOut_BufferFull
     ldw        r1, r3[3]                        // Load buffer from EP structure
@@ -42,12 +36,18 @@ DoOutNonIso:
 
 doRXDataReturn_NonIso:
     bf         r1, NextTokenAfterOut            // Check for bad crc
-    ldc        r11, USB_PIDn_ACK                // Data CRC good and EP not Iso: Send Ack
-    nop
-    nop
-    nop
-    nop
-    nop
+
+    ldaw       r6,  dp[handshakeTable_OUT]      // Load the handshake table.
+   {ldw        r11, r6[r10]                     // Get the handshake PID for this EP
+    ldc        r1,  USB_PIDn_STALL}             // as well as the STALL PID
+    eq         r1,  r11, r1                     // and compare them.
+    nop                                         // NOP to ensure minimum interpacket delay.
+    bt         r1,  XUD_TokenOut_Handshake      // If the handshake PID for this EP is STALL, then
+                                                // go and send the handshake without clearing ready
+                                                // or communicating back to the application that
+                                                // the packet has been received.
+
+    ldc        r11, USB_PIDn_ACK                // Data CRC good, EP not Iso, and EP not halted: Send Ack
     outpw      res[TXD], r11, 8
     syncr      res[TXD]
 
@@ -92,8 +92,9 @@ XUD_TokenOut_WaitForPacketEnd:                  // Wait for end of data then sen
 #endif
 
   // Load handshake (ACK or STALL)
-  ldaw       r5, dp[handshakeTable_OUT]         // Load handshake table
-  ldw        r11, r5[r10]
+  ldaw      r6, dp[handshakeTable_OUT]          // Load handshake table
+XUD_TokenOut_Handshake:
+  ldw       r11, r6[r10]
   outpw     res[TXD], r11, 8
   syncr     res[TXD]
 


### PR DESCRIPTION
If an OUT endpoint stalls and then subsequently waits for data, for
example with XUD_GetBuffer(), the endpoint will continue to respond with
STALL handshakes until the stall condition is cleared.

This fixes #58.

This also fixes my issue #129. I have also confirmed that both USB_StandardRequests() in lib_xud, and the Tiny USB stack will clear stalls when EndPoint ClearFeature requests are received, so there is no longer a need to implement the type of workaround in aisrv.