### PR TITLE
Provide VBUS detect function.

### DIFF
--- a/lib_xud/src/core/XUD_Default.c
+++ b/lib_xud/src/core/XUD_Default.c
@@ -1,0 +1,20 @@
+// Copyright 2019-2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#if defined(__XS3A__)
+unsigned int XUD_HAL_GetVBusState(void) __attribute__((weak));
+#endif
+unsigned int XUD_HAL_GetVBusState(void)
+{
+#if defined(__XS3A__)
+    return 1u;
+#elif defined(__XS2A__)
+    unsigned int x;
+
+    read_periph_word(USB_TILE_REF, XS1_GLX_PER_UIFM_CHANEND_NUM, XS1_GLX_PER_UIFM_OTG_FLAGS_NUM, x);
+
+    return x & (1 << XS1_UIFM_OTG_FLAGS_SESSVLDB_SHIFT);
+#else
+#error no architecture defined
+#endif
+}

--- a/lib_xud/src/core/XUD_DeviceAttach.xc
+++ b/lib_xud/src/core/XUD_DeviceAttach.xc
@@ -94,18 +94,11 @@ int XUD_DeviceAttachHS(XUD_PwrConfig pwrConfig)
 #endif
                     if(pwrConfig == XUD_PWR_SELF) 
                     {
-                        unsigned x;
-#ifdef __XS3A__
-                        #warning VBUS checking in failed HS handhake missing from XS3A
-#else
-                        read_periph_word(USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM, XS1_SU_PER_UIFM_OTG_FLAGS_NUM, x);
-                   
-                        if(!(x&(1<<XS1_SU_UIFM_OTG_FLAGS_SESSVLDB_SHIFT))) 
+                        if(!XUD_HAL_GetVBusState())
                         {
                             write_periph_word(USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM, XS1_SU_PER_UIFM_FUNC_CONTROL_NUM, 4);
                              return -1;             // VBUS gone, handshake fails completely.
                         }
-#endif
                     }
                 }
                 break;

--- a/lib_xud/src/core/XUD_HAL.h
+++ b/lib_xud/src/core/XUD_HAL.h
@@ -75,3 +75,10 @@ void XUD_HAL_SetDeviceAddress(unsigned char address);
  **/
 void XUD_HAL_EnableUsb(unsigned pwrConfig);
 
+/**
+ * \brief  HAL funtion to get state of VBUS line, if any
+ * \param  none
+ * \return unsigned int non-zero if VBUS asserted, zero otherwise
+ **/
+unsigned int XUD_HAL_GetVBusState(void);
+

--- a/lib_xud/src/core/XUD_HAL.xc
+++ b/lib_xud/src/core/XUD_HAL.xc
@@ -365,6 +365,3 @@ void XUD_HAL_SetDeviceAddress(unsigned char address)
     write_periph_word(USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM, XS1_SU_PER_UIFM_DEVICE_ADDRESS_NUM, address);
 #endif
 }
-
-
-

--- a/lib_xud/src/core/XUD_Main.xc
+++ b/lib_xud/src/core/XUD_Main.xc
@@ -272,14 +272,10 @@ static int XUD_Manager_loop(XUD_chan epChans0[], XUD_chan epChans[],  chanend ?c
                 {
                     while(1)
                     {
-                        unsigned x, time;
+                        unsigned time;
                         timer t;
-#if defined(__XS2A__)
-                        read_periph_word(USB_TILE_REF, XS1_GLX_PER_UIFM_CHANEND_NUM, XS1_GLX_PER_UIFM_OTG_FLAGS_NUM, x);
-                        if(x&(1<<XS1_UIFM_OTG_FLAGS_SESSVLDB_SHIFT))
-#else
-                        #warning XS3 wait for VBUS not implemented
-#endif
+
+                        if(XUD_HAL_GetVBusState())
                         {
                             break;
                         }

--- a/lib_xud/src/core/XUD_PowerSig.xc
+++ b/lib_xud/src/core/XUD_PowerSig.xc
@@ -128,7 +128,6 @@ int XUD_Init()
   * @return True if reset detected during resume */
 int XUD_Suspend(XUD_PwrConfig pwrConfig)
 {
-    unsigned tmp;
     timer t;
     unsigned time;
 
@@ -144,8 +143,7 @@ int XUD_Suspend(XUD_PwrConfig pwrConfig)
         select
         {
             case (pwrConfig == XUD_PWR_SELF) => t when timerafter(time + SUSPEND_VBUS_POLL_TIMER_TICKS) :> void:
-                read_periph_word(USB_TILE_REF,  XS1_SU_PER_UIFM_CHANEND_NUM, XS1_SU_PER_UIFM_OTG_FLAGS_NUM, tmp);
-                if (!(tmp & (1 << XS1_SU_UIFM_OTG_FLAGS_SESSVLDB_SHIFT)))
+                if(!XUD_HAL_GetVBusState())
                 {
                     // VBUS not valid
                     write_periph_word(USB_TILE_REF, XS1_SU_PER_UIFM_CHANEND_NUM,  XS1_SU_PER_UIFM_FUNC_CONTROL_NUM, 4 /* OpMode 01 */);


### PR DESCRIPTION
The function XUD_GetVBusState() will get the state of the VBUS detection circuit. On XS3 architecture it has weak linkage to allow it to be overridden with an application-specific version. This addresses issue #66 .