### PR TITLE
Fix/237

### DIFF
--- a/examples/AN00129_hid_class/Makefile
+++ b/examples/AN00129_hid_class/Makefile
@@ -1,14 +1,3 @@
-# The TARGET variable determines what target system the application is 
-# compiled for. It either refers to an XN file in the source directories
-# or a valid argument for the --target option when compiling.
-
-# In this case, the target depends on the build configuration.
-ifeq ($(CONFIG),X200)
-TARGET = XCORE-200-EXPLORER
-else
-TARGET = XCORE-AI-EXPLORER-NO-DDR.xn
-endif
-
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to 
 # the project name
@@ -22,14 +11,26 @@ APP_NAME = app_hid_mouse_demo
 # If the variable XCC_MAP_FLAGS is set it overrides the flags passed to 
 # xcc for the final link (mapping) stage.
 
-# These flags define two build configurations - one for U-series and one for
-# the xCORE-200 series.
+# These flags define two build configurations - one for xCORE-200 and one for
+# the xCORE.AI series.
+BUILD_FLAGS = -O3 -report
 
-XCC_FLAGS_X200  = -O3 -report -DXUD_SERIES_SUPPORT=XUD_X200_SERIES
-XCC_FLAGS_AI  = -O3 -report
+XCC_FLAGS_200 = $(BUILD_FLAGS) -DXUD_CORE_CLOCK=500
+XCC_FLAGS_AI = $(BUILD_FLAGS) -DXUD_CORE_CLOCK=600
 
 # The USED_MODULES variable lists other module used by the application. 
 USED_MODULES = lib_xud
+
+# The TARGET variable determines what target system the application is 
+# compiled for. It either refers to an XN file in the source directories
+# or a valid argument for the --target option when compiling.
+
+# In this case, the target depends on the build configuration.
+ifeq ($(CONFIG),AI)
+TARGET = XCORE-AI-EXPLORER
+else
+TARGET = XCORE-200-EXPLORER
+endif
 
 #=============================================================================
 # The following part of the Makefile includes the common build infrastructure

--- a/lib_xud/src/core/XUD_HAL.xc
+++ b/lib_xud/src/core/XUD_HAL.xc
@@ -53,7 +53,6 @@ unsigned int XUD_EnableUsbPortMux();
 void XUD_HAL_EnableUsb(unsigned pwrConfig)
 {
     /* For xCORE-200 enable USB port muxing before enabling phy etc */
-    // TODO inline ASM here
     XUD_EnableUsbPortMux(); //setps(XS1_PS_XCORE_CTRL0, UIFM_MODE);
 
 #ifndef XUD_SIM_XSIM
@@ -377,10 +376,10 @@ unsigned XUD_HAL_WaitForLineStateChange(XUD_LineState_t &currentLs, unsigned tim
     currentLs = LinesToLineState(dp, dm);
     return 0;
 #else
-    #warning TODO for XS2A
+    //TODO XUD_HAL_WaitForLineStateChange() not implemented for XS2
+    //Note, this is not currently used for XS2
     return 1;
 #endif
-    
 }
 
 void XUD_HAL_SetDeviceAddress(unsigned char address)


### PR DESCRIPTION
Addresses issue #237

#warning was for  XUD_HAL_WaitForLineStateChange() not being implemented for XS2

I have removed the #warning and replaced with a comment. This is because XS2 doesn't use this function. The use of XUD_HAL_WaitForLineStateChange() is covered by #63 (Hardware Abstraction Layer (HAL) is not yet complete)
