### PR TITLE
Updated clockblocks from 2/3 to 4/5

### DIFF
--- a/lib_xud/src/core/XUD_Main.xc
+++ b/lib_xud/src/core/XUD_Main.xc
@@ -56,8 +56,8 @@ out port tx_readyout           = PORT_USB_TX_READYOUT;
 in port tx_readyin             = PORT_USB_TX_READYIN;
 in port rx_rdy                 = PORT_USB_RX_READY;
 
-on USB_TILE: clock tx_usb_clk  = XS1_CLKBLK_2;
-on USB_TILE: clock rx_usb_clk  = XS1_CLKBLK_3;
+on USB_TILE: clock tx_usb_clk  = XS1_CLKBLK_4;
+on USB_TILE: clock rx_usb_clk  = XS1_CLKBLK_5;
 
 XUD_chan epChans[USB_MAX_NUM_EP];
 XUD_chan epChans0[USB_MAX_NUM_EP];


### PR DESCRIPTION
Addresses #253 

Clockblock numbers changed as requested by external user. Matches old U-series code.

(Note, documentation updated in #169)