### PR TITLE
example/xcoverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,13 @@ PARAMS = {
 def pytest_addoption(parser):
     parser.addoption("--smoke", action="store_true", help="Smoke test")
     parser.addoption("--extended", action="store_true", help="Extended test")
-    parser.addoption("--xcov", action="store", help="Enable xcov, set a limit for test coverage", type=int, default=0)
+    parser.addoption(
+        "--xcov",
+        action="store",
+        help="Enable xcov, set a limit for test coverage",
+        type=int,
+        default=0,
+    )
     parser.addoption(
         "--enabletracing",
         action="store_true",
@@ -156,7 +162,7 @@ def test_RunUsbSession(
     results = Pyxsim.run_tester(output, tester_list)
 
     # calculate code coverage for each tests
-    coverage = handler_process(disasm,trace,xcov_dir)
+    coverage = handler_process(disasm, trace, xcov_dir)
     # generate coverage file for each source code included
     handler_combine(xcov_dir)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,7 +255,7 @@ def xcoverage_combination(tmp_path_factory, worker_id, request):
     # run xcoverage combine test at the end of pytest
     def run_at_end():
         coverage = combine_test.do_combine_test(test_dirs)
-        combine_test.generate_merge_src("result")
+        combine_test.generate_merge_src()
         combine_test.close_fd()
         # teardowm - remove tmp file
         combine_test.remove_tmp_testresult(combine_test.tpath)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 from helpers import get_usb_clk_phy, do_usb_test
 import Pyxsim
-from xcoverage.xcov import handler_process, handler_combine
+from xcoverage.xcov import xcov_process, xcov_combine
 
 # Note, no current support for XS2 so don't copy XS2 xn files
 XN_FILES = ["test_xs3_600.xn", "test_xs3_800.xn", "test_xs3_540.xn", "test_xs3_500.xn"]
@@ -162,17 +162,18 @@ def test_RunUsbSession(
     results = Pyxsim.run_tester(output, tester_list)
 
     # calculate code coverage for each tests
-    coverage = handler_process(disasm, trace, xcov_dir)
+    coverage = xcov_process(disasm, trace, xcov_dir)
     # generate coverage file for each source code included
-    handler_combine(xcov_dir)
+    xcov_combine(xcov_dir)
 
     # TODO only one result
     for result in results:
         if not result:
             print(cap_output)
             sys.stderr.write(err)
-        if coverage < xcov:
-            assert False
+        else:
+            if coverage < xcov:
+                assert False
         assert result
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -277,8 +277,8 @@ def xcoverage_combination(tmp_path_factory, worker_id, request):
                 for tmp_testfile in combine_test.find_testresult(combine_test.tpath):
                     pid = pid_re.match(tmp_testfile)
                     pid = pid.group(1)
-                    if pid != os.getpid():
-                        while(psutil.pid_exists(pid)):
+                    if int(pid) != os.getpid():
+                        while(psutil.pid_exists(int(pid))):
                             time.sleep(0.05)
 
                 coverage = combine_test.do_combine_test(test_dirs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,8 +168,8 @@ def test_RunUsbSession(
                 coverage = xcov_process(disasm, trace, xcov_dir)
                 # generate coverage file for each source code included
                 xcov_combine(xcov_dir)
-                # delete_logs(trace)
         assert result
+
 
 def copy_common_xn_files(
     test_dir,
@@ -182,15 +182,6 @@ def copy_common_xn_files(
         xn = os.path.join(common_dir, xn_file)
         shutil.copy(xn, src_dir)
 
-# def delete_logs(logsfile):
-#     if os.path.isfile(logsfile):
-#         try:
-#             print("delete %s" % logsfile)
-#             os.remove(logsfile)
-#         except Exception as e:
-#             print(e)
-#     else:
-#         print("%s not found" % logsfile)
 
 def delete_test_specific_xn_files(test_dir, source_dir="src", xn_files=XN_FILES):
     src_dir = os.path.join(test_dir, source_dir)
@@ -250,12 +241,14 @@ def copy_xn_files(worker_id, request):
     # Deletion removed for now - doesn't seem important
     # request.addfinalizer(delete_xn_files)
 
+
 @pytest.fixture(scope="session", autouse=True)
 def xcoverage_combination(worker_id, request):
-    #run xcoverage combine test at the end of pytest
+    # run xcoverage combine test at the end of pytest
     def run_combination():
         global test_dirs
         if worker_id in ("master", "gw0"):
             current_path = os.getcwd()
-            coverage = combine_tests(current_path,test_dirs)
+            coverage = combine_tests(current_path, test_dirs)
+
     request.addfinalizer(run_combination)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -93,8 +93,11 @@ def run_on(**kwargs):
 
     return True
 
+
 def generate_elf_disasm(binary, split_dir, disasm):
-    cmd_elf = "xobjdump --split " + binary + " --split-dir " + split_dir + " > /dev/null 2>&1"
+    cmd_elf = (
+        "xobjdump --split " + binary + " --split-dir " + split_dir + " > /dev/null 2>&1"
+    )
     cmd_disasm = "xobjdump -S " + binary + " -o " + disasm
     try:
         subprocess.run(cmd_elf, shell=True, check=True)
@@ -102,6 +105,7 @@ def generate_elf_disasm(binary, split_dir, disasm):
     except:
         print("Error running build disasm")
         sys.exit(1)
+
 
 FIXTURE_TO_DEFINE = {
     "core_freq": "TEST_FREQ",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,6 +8,7 @@ from Pyxsim import testers
 from usb_clock import Clock
 from usb_phy_utmi import UsbPhyUtmi
 import Pyxsim
+import subprocess
 
 ARCHITECTURE_CHOICES = ["xs2", "xs3"]
 BUSSPEED_CHOICES = ["FS", "HS"]
@@ -92,6 +93,15 @@ def run_on(**kwargs):
 
     return True
 
+def generate_elf_disasm(binary, split_dir, disasm):
+    cmd_elf = "xobjdump --split " + binary + " --split-dir " + split_dir + " > /dev/null 2>&1"
+    cmd_disasm = "xobjdump -S " + binary + " -o " + disasm
+    try:
+        subprocess.run(cmd_elf, shell=True, check=True)
+        subprocess.run(cmd_disasm, shell=True, check=True)
+    except:
+        print("Error running build disasm")
+        sys.exit(1)
 
 FIXTURE_TO_DEFINE = {
     "core_freq": "TEST_FREQ",
@@ -112,6 +122,7 @@ def do_usb_test(
     core_freq,
     clk,
     phy,
+    xcov,
     sessions,
     test_file,
     extra_tasks=[],
@@ -146,6 +157,12 @@ def do_usb_test(
 
     assert len(sessions) == 1, "Multiple sessions not yet supported"
     if build_success:
+
+        if xcov:
+            split_dir = f"{testname}/bin/{desc}/"
+            disasm = f"{testname}/bin/{desc}/{testname}_{desc}.dump"
+            generate_elf_disasm(binary, split_dir, disasm)
+
         for session in sessions:
 
             phy.session = session
@@ -169,7 +186,7 @@ def do_usb_test(
             )
 
             tester_list.append(tester)
-            simargs = get_sim_args(testname, clk, arch)
+            simargs = get_sim_args(testname, desc)
             simthreads = [clk, phy] + extra_tasks
             run_on_simulator(binary, simthreads, simargs=simargs)
     else:
@@ -205,17 +222,16 @@ def create_expect(session, filename, verbose=False):
             print("Test done\n")
 
 
-def get_sim_args(testname, clk, arch="xs2"):
+def get_sim_args(testname, desc):
     sim_args = []
 
     if eval(os.getenv("enabletracing")):
         log_folder = create_if_needed("logs")
 
-        filename = "{log}/xsim_trace_{test}_{clk}_{arch}".format(
+        filename = "{log}/xsim_trace_{test}_{desc}".format(
             log=log_folder,
             test=testname,
-            clk=clk.get_name(),
-            arch=arch,
+            desc=desc,
         )
 
         sim_args += [

--- a/tests/test_makefile.mak
+++ b/tests/test_makefile.mak
@@ -16,6 +16,7 @@ SHARED_CODE = ../../shared_src
 
 COMMON_FLAGS = -DDEBUG_PRINT_ENABLE \
 			   -O3 \
+			   -g \
 			   -I$(SHARED_CODE) \
 			   -DUSB_TILE=tile[0] \
 			   -DXUD_SIM_XSIM=1 \


### PR DESCRIPTION
An example to show using xcoverage in pytest

ex: python -m pytest --junitxml=pytest_result.xml --numprocesses=1 --enabletracing --xcov 10