### PR TITLE
Add buildDiscarder and timestamp option to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,12 @@ pipeline {
   }
   options {
     skipDefaultCheckout()
+    timestamps()
+    // on develop discard builds after a certain number else keep forever
+    buildDiscarder(logRotator(
+        numToKeepStr:         env.BRANCH_NAME ==~ /develop/ ? '100' : '',
+        artifactNumToKeepStr: env.BRANCH_NAME ==~ /develop/ ? '100' : ''
+    ))
   }
   stages {
     stage('Get view') {

--- a/lib_xud/src/core/XUD_IoLoop.S
+++ b/lib_xud/src/core/XUD_IoLoop.S
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 XMOS LIMITED.
+// Copyright 2011-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 // XUD_IoLoop.S


### PR DESCRIPTION
This PR introduces a method for automatically deleting Jenkins builds after a certain time/number. This is needed so that Jenkins disk does not forever grow.

Please understand that **THIS IS A DESTRUCTIVE CHANGE** and once merged to develop will permanently delete old builds so please come forward with any concerns over the settings chosen if you have any.

We will use the [buildDiscarder Jenkinsfile option](https://stackoverflow.com/questions/39542485/how-to-write-pipeline-to-discard-old-builds/44155346#44155346) to configure this on a repo-by-repo basis.

This process has been tested using [this repo](https://github.com/xmos/jenkins_test) and [this jenkins job](http://srv-bri-jcim0:8080/job/XMOS/job/jenkins_test/).

------------------------

[Here is a link to the confluence page](https://xmosjira.atlassian.net/wiki/spaces/wiki/pages/3396534277/Build+Discarding) going into more detail about justification and usage.

The short version is we propose to delete any build older than 100 on the develop branch of this repo.

Please comment if you think this is unsuitable.

------------------------

PS I have also opted to use this opportunity to add the timestamps option to jobs that do not already employ it. This makes it easier to diagnose any future Jenkins issues.
