### PR TITLE
Fix stringDescriptors declaration for XC

### DIFF
--- a/examples/AN00129_hid_class/src/hid_defs.h
+++ b/examples/AN00129_hid_class/src/hid_defs.h
@@ -1,4 +1,4 @@
-// Copyright 2021 XMOS LIMITED.
+// Copyright 2021-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /*
@@ -126,12 +126,20 @@ static unsigned char hidReportDescriptor[] =
 };
 
 /* String table */
+#ifdef __XC__
+unsafe {
+static char * unsafe stringDescriptors[]=
+#else
 static char * stringDescriptors[]=
+#endif // __XC__
 {
     "\x09\x04",             // Language ID string (US English)
     "XMOS",                 // iManufacturer
     "Example HID Mouse",    // iProduct
     "Config",               // iConfiguration
 };
+#ifdef __XC__
+}
+#endif // __XC__
 
 #endif // HID_DEFS_H


### PR DESCRIPTION
Without an unsafe block the AN00129_hid_class example is crashing on x200 with the following error:
```
xrun: Program received signal ET_LOAD_STORE, Memory access exception.
      [Switching to tile[0] core[1]]
      0x00042ee4 in strnlen ()
```
And the following stacktrace:
```
6 strnlen() 0x00042ee4
5 _safe_strlen() 0x00042dc4
4 USB_StandardRequests() xud_device.xc:392 0x00041c45
3 Endpoint0() 0x00040695
...
```
The crash was bisected to commit 9b14001 and it was checked that adding unsafe block (and unsafe keyword for `stringDescriptors`) resolves the issue.