### PR TITLE
Fix/342

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ UNRELEASED
 ----------
 
   * CHANGE:    Further API functions re-authored in C (were Assembly)
+  * CHANGE:    Endpoints marked as Disabled now reply with STALL if the host
+    attempts to access them, previously they would NAK
   * FIXED:     Exception if host accesses an endpoint that XUD believes to be
     not in use
   * FIXED:     Timeout event properly cleaned up after tx handshake received

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.16.2') _
+@Library('xmos_jenkins_shared_library@v0.18.0') _
 
 getApproval()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,11 @@ pipeline {
             }
           }
         }
-        archiveArtifacts artifacts: "${REPO}/tests/logs/*.txt", fingerprint: true, allowEmptyArchive: true, onlyIfSuccessful: false
-        archiveArtifacts artifacts: "${REPO}/tests/logs/*.vcd", fingerprint: true, allowEmptyArchive: true, onlyIfSuccessful: false
+      }
+       post {
+        failure {
+          archiveArtifacts artifacts: "${REPO}/tests/logs/*.txt", fingerprint: true, allowEmptyArchive: true
+          archiveArtifacts artifacts: "${REPO}/tests/logs/*.vcd", fingerprint: true, allowEmptyArchive: true
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,6 @@ pipeline {
        post {
         failure {
           archiveArtifacts artifacts: "${REPO}/tests/logs/*.txt", fingerprint: true, allowEmptyArchive: true
-          archiveArtifacts artifacts: "${REPO}/tests/logs/*.vcd", fingerprint: true, allowEmptyArchive: true
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,8 @@ pipeline {
         archiveArtifacts artifacts: "${REPO}/**/pdf/*.pdf", fingerprint: true, allowEmptyArchive: true
       }
     }
-    stage('Tests') {
+    stage('Tests') 
+    {
       steps {
         dir("${REPO}/tests"){
           viewEnv(){
@@ -53,9 +54,12 @@ pipeline {
           }
         }
       }
-       post {
-        failure {
+       post 
+       {
+        failure 
+        {
           archiveArtifacts artifacts: "${REPO}/tests/logs/*.txt", fingerprint: true, allowEmptyArchive: true
+        }
       }
     }
   }

--- a/lib_xud/src/core/XUD_Main.xc
+++ b/lib_xud/src/core/XUD_Main.xc
@@ -64,7 +64,7 @@ on USB_TILE: clock rx_usb_clk  = XS1_CLKBLK_5;
 // unsigned epAddr_Ready[USB_MAN_NUM_EP]
 // unsigned epAddr_Ready[USB_MAX_NUM_EP_OUT]
 unsigned epAddr[USB_MAX_NUM_EP];                        // Used to store the addr of each EP in ep_info array
-unsigned epAddr_Ready[USB_MAX_NUM_EP + USB_MAX_NUM_EP_OUT];    // Used by the EP to mark itself as ready, essentially same as epAddr_Ready with 0 entries.
+unsigned epAddr_Ready[USB_MAX_NUM_EP + USB_MAX_NUM_EP_OUT];    // Used by the EP to mark itself as ready, essentially same as epAddr with 0 entries.
 
 XUD_chan epChans0[USB_MAX_NUM_EP];
 
@@ -481,7 +481,6 @@ int XUD_Main(chanend c_ep_out[], int noEpOut,
         epAddr_Ready[USB_MAX_NUM_EP_OUT+i] = 0;
         ep_info[USB_MAX_NUM_EP_OUT+i].epAddress = (i | 0x80);
         ep_info[USB_MAX_NUM_EP_OUT+i].resetting = 0;
-        
         ep_info[USB_MAX_NUM_EP_OUT+i].halted = USB_PIDn_STALL;
         
         asm("ldaw %0, %1[%2]":"=r"(x):"r"(ep_info),"r"((USB_MAX_NUM_EP_OUT+i)*sizeof(XUD_ep_info)/sizeof(unsigned)));

--- a/tests/shared/shared.h
+++ b/tests/shared/shared.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <platform.h>
 #include <stdint.h>
+#include <assert.h>
 #include "xud.h"
 
 void exit(int);

--- a/tests/shared/test_main.xc
+++ b/tests/shared/test_main.xc
@@ -23,7 +23,13 @@ int main()
 #error XUD_TEST_SPEED must be defined
 #endif
 		 	const unsigned speed = XUD_TEST_SPEED;
-            
+           
+            const int epCountOut = sizeof(epTypeTableOut)/sizeof(epTypeTableOut[0]);
+            const int epCountIn = sizeof(epTypeTableIn)/sizeof(epTypeTableIn[0]);
+
+            assert(epCountOut == EP_COUNT_OUT);
+            assert(epCountIn == EP_COUNT_IN);
+
             XUD_Main(c_ep_out, EP_COUNT_OUT, c_ep_in, EP_COUNT_IN,
                                 null, epTypeTableOut, epTypeTableIn,
                                 speed, XUD_PWR_BUS);

--- a/tests/test_disabled_ep.py
+++ b/tests/test_disabled_ep.py
@@ -1,0 +1,135 @@
+# Copyright 2016-2022 XMOS LIMITED.
+# This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+# This test makes sure traffic to endpoints that are marked disabled behave as expected
+# Note, test assumes EP is never 3, 5 or 6
+
+import pytest
+
+from conftest import PARAMS, test_RunUsbSession  # noqa F401
+from usb_session import UsbSession
+from usb_transaction import UsbTransaction
+
+
+@pytest.fixture
+def test_session(ep, address, bus_speed):
+
+    # Check not clashing against EP's marked disabled or we expect to nak
+    assert ep not in [3, 5, 6]
+
+    pktLength = 10
+
+    session = UsbSession(
+        bus_speed=bus_speed, run_enumeration=False, device_address=address
+    )
+
+    # Valid transactions on test EP's
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=ep,
+            endpointType="BULK",
+            transType="OUT",
+            dataLength=pktLength,
+        )
+    )
+
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=ep,
+            endpointType="BULK",
+            transType="IN",
+            dataLength=pktLength,
+        )
+    )
+
+    # Try some other endpoints that should not be used - expect STALL
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=3,
+            endpointType="BULK",
+            transType="OUT",
+            dataLength=pktLength,
+            halted=True,
+        )
+    )
+
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=5,
+            endpointType="BULK",
+            transType="OUT",
+            dataLength=pktLength,
+            halted=True,
+        )
+    )
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=3,
+            endpointType="BULK",
+            transType="IN",
+            dataLength=pktLength,
+            halted=True,
+        )
+    )
+
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=5,
+            endpointType="BULK",
+            transType="IN",
+            dataLength=pktLength,
+            halted=True,
+        )
+    )
+
+    # This EP is marked enabled but never marked ready, should NAK
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=6,
+            endpointType="BULK",
+            transType="OUT",
+            dataLength=pktLength,
+            nacking=True,
+        )
+    )
+
+    # This EP is marked enabled but never marked ready, should NAK
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=6,
+            endpointType="BULK",
+            transType="IN",
+            dataLength=pktLength,
+            nacking=True,
+        )
+    )
+
+    # Valid transactions on test EP finishes the test
+    session.add_event(
+        UsbTransaction(
+            session,
+            deviceAddress=address,
+            endpointNumber=ep,
+            endpointType="BULK",
+            transType="OUT",
+            dataLength=pktLength,
+        )
+    )
+
+    return session

--- a/tests/test_disabled_ep/Makefile
+++ b/tests/test_disabled_ep/Makefile
@@ -1,0 +1,3 @@
+TEST_FLAGS = -DXUD_BYPASS_RESET=1 
+
+include ../test_makefile.mak

--- a/tests/test_disabled_ep/src/test.xc
+++ b/tests/test_disabled_ep/src/test.xc
@@ -1,0 +1,51 @@
+// Copyright 2016-2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#define EP_COUNT_OUT        (7)
+#define EP_COUNT_IN         (7)
+
+#ifndef PKT_LENGTH_START
+#define PKT_LENGTH_START    (10)
+#endif
+
+#ifndef PKT_LENGTH_END
+#define PKT_LENGTH_END      (19)
+#endif
+
+#include "shared.h"
+
+/* The test bench will use either ep 1, 2, or 4 for the "test EP" */
+
+XUD_EpType epTypeTableOut[EP_COUNT_OUT] = {XUD_EPTYPE_CTL, XUD_EPTYPE_BUL, XUD_EPTYPE_BUL, XUD_EPTYPE_DIS, XUD_EPTYPE_BUL, XUD_EPTYPE_DIS, XUD_EPTYPE_BUL};
+XUD_EpType epTypeTableIn[EP_COUNT_IN] =   {XUD_EPTYPE_CTL, XUD_EPTYPE_BUL, XUD_EPTYPE_BUL, XUD_EPTYPE_DIS, XUD_EPTYPE_BUL, XUD_EPTYPE_DIS, XUD_EPTYPE_BUL};
+
+unsigned test_func(chanend c_ep_out[EP_COUNT_OUT], chanend c_ep_in[EP_COUNT_IN])
+{
+    unsigned failed = 0;
+    uint8_t outBuffer0[128];
+    uint8_t inBuffer0[128];
+    unsigned length;
+    XUD_Result_t result;
+    
+    for(size_t i = 0; i < PKT_LENGTH_START; i++)
+    {
+        inBuffer0[i] = i;
+    }
+
+    XUD_ep ep_out = XUD_InitEp(c_ep_out[TEST_EP_NUM]);
+    XUD_ep ep_in = XUD_InitEp(c_ep_in[TEST_EP_NUM]);
+    
+    result = XUD_GetBuffer(ep_out, outBuffer0, length);
+    failed = (result != XUD_RES_OKAY);
+
+    result = XUD_SetBuffer(ep_in, inBuffer0, PKT_LENGTH_START);
+    failed |= (result != XUD_RES_OKAY);
+
+    result = XUD_GetBuffer(ep_out, outBuffer0, length);
+    failed = (result != XUD_RES_OKAY);
+   
+    return failed;
+}
+
+#include "test_main.xc"
+


### PR DESCRIPTION
Addresses #342 (missing test)

Also:
- Added (non-critical) fix that this test raised: Potential for slight race condition when endpoint is sent it's address before state is completely setup
- Disabled endpoints now reply STALL (previously NAKed) if accessed by host
- Test-code now checks for valid ep count defines
- Test-bench can now deal with NAKing EP’s

This PR also updates xmos_jenkins_shared_library to the latest release