### PR TITLE
Avoid race when test processes create directories

### DIFF
--- a/__app_test_mode/src/main.xc
+++ b/__app_test_mode/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 XMOS LIMITED.
+// Copyright 2020-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xud_device.h"
 

--- a/examples/AN00124_CDC_VCOM_class/src/main.xc
+++ b/examples/AN00124_CDC_VCOM_class/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <platform.h>

--- a/examples/AN00125_mass_storage_class/src/main.xc
+++ b/examples/AN00125_mass_storage_class/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xscope.h>

--- a/examples/AN00125_mass_storage_class/src/mass_storage.xc
+++ b/examples/AN00125_mass_storage_class/src/mass_storage.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xs1.h>

--- a/examples/AN00126_printer_class/src/main.xc
+++ b/examples/AN00126_printer_class/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xud_device.h"
 #include "debug_print.h"

--- a/examples/AN00127_video_class/src/main.xc
+++ b/examples/AN00127_video_class/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /* Includes */

--- a/examples/AN00129_hid_class/src/main.xc
+++ b/examples/AN00129_hid_class/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xud_device.h"
 #include "hid_defs.h"

--- a/examples/AN00131_CDC_EDC_class/src/eth_tcp/femtoTCP.xc
+++ b/examples/AN00131_CDC_EDC_class/src/eth_tcp/femtoTCP.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xclib.h>

--- a/examples/AN00131_CDC_EDC_class/src/main.xc
+++ b/examples/AN00131_CDC_EDC_class/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <platform.h>

--- a/examples/AN00132_image_class/host/ptp.h
+++ b/examples/AN00132_image_class/host/ptp.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef __PTP_H__

--- a/examples/AN00135_test_and_measurement_class/src/main.xc
+++ b/examples/AN00135_test_and_measurement_class/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include "xud_device.h"

--- a/examples/AN00136_vendor_specific/src/main.xc
+++ b/examples/AN00136_vendor_specific/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <platform.h>

--- a/lib_xud/src/core/XUD_DeviceAttach.xc
+++ b/lib_xud/src/core/XUD_DeviceAttach.xc
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 XMOS LIMITED.
+// Copyright 2011-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #if !defined(XUD_BYPASS_RESET)
 #include <xs1.h>

--- a/lib_xud/src/core/XUD_HAL.h
+++ b/lib_xud/src/core/XUD_HAL.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2019-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /**

--- a/lib_xud/src/core/XUD_TestMode.xc
+++ b/lib_xud/src/core/XUD_TestMode.xc
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 XMOS LIMITED.
+// Copyright 2011-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 

--- a/lib_xud/src/core/XUD_TimingDefines.h
+++ b/lib_xud/src/core/XUD_TimingDefines.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef _XUD_USB_DEFINES_H_
 #define _XUD_USB_DEFINES_H_

--- a/lib_xud/src/core/XUD_TokenJmp.S
+++ b/lib_xud/src/core/XUD_TokenJmp.S
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 XMOS LIMITED.
+// Copyright 2013-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef __XS3A__

--- a/lib_xud/src/core/XUD_USBTile_Support.S
+++ b/lib_xud/src/core/XUD_USBTile_Support.S
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 /** XUD_USBTile_Support.S
   * @brief     Support functions for USB Tile use

--- a/lib_xud/src/core/included/XUD_Token_Ping.S
+++ b/lib_xud/src/core/included/XUD_Token_Ping.S
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 XMOS LIMITED.
+// Copyright 2011-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "XUD_AlignmentDefines.h"
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,8 @@ args = {"arch": "xs3"}
 
 def create_if_needed(folder):
     if not os.path.exists(folder):
-        os.makedirs(folder)
+        # exist_ok avoids exception when multiple test processes create at the same time
+        os.makedirs(folder, exist_ok=True)
     return folder
 
 

--- a/tests/suspend_resume_functional/test.xc
+++ b/tests/suspend_resume_functional/test.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2018-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <stdio.h>

--- a/tests/test_bulk_notready/src/main.xc
+++ b/tests/test_bulk_notready/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #define EP_COUNT_OUT   		(6)
 #define EP_COUNT_IN    		(6)

--- a/tests/test_bulk_rx_multiep/src/main.xc
+++ b/tests/test_bulk_rx_multiep/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "shared.h"
 

--- a/tests/test_bulk_tx_badack/src/main.xc
+++ b/tests/test_bulk_tx_badack/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef PKT_LENGTH_START

--- a/tests/test_bulk_tx_multiep/src/main.xc
+++ b/tests/test_bulk_tx_multiep/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define EP_COUNT_OUT       (5)

--- a/tests/test_iso_tx_basic/src/main.xc
+++ b/tests/test_iso_tx_basic/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef EP_COUNT_OUT

--- a/tests/test_ping_stall/src/main.xc
+++ b/tests/test_ping_stall/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define EP_COUNT_OUT       (6)

--- a/tests/test_shorttoken/src/main.xc
+++ b/tests/test_shorttoken/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <print.h>

--- a/tests/test_sof_badcrc/src/main.xc
+++ b/tests/test_sof_badcrc/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <print.h>

--- a/tests/test_stall_epready_in/src/main.xc
+++ b/tests/test_stall_epready_in/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 

--- a/tests/test_stall_epready_out/src/main.xc
+++ b/tests/test_stall_epready_out/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 


### PR DESCRIPTION
There are occasional failures on the first testcase in the nightly tests where multiple test processes see that the directory to be created does not exist, but then only the first `os.makedirs` will succeed and others will fail because the directory now exists. Setting the `exist_ok` parameter will avoid this exception.