### PR TITLE
Remove compiler warnings

### DIFF
--- a/lib_xud/src/user/client/XUD_EpFunctions.c
+++ b/lib_xud/src/user/client/XUD_EpFunctions.c
@@ -190,7 +190,7 @@ XUD_Result_t XUD_GetBuffer(XUD_ep e, unsigned char buffer[], unsigned *datalengt
             return XUD_RES_RST;
         }
 
-        result = XUD_GetBuffer_Finish(ep->client_chanend, ep, datalength);
+        result = XUD_GetBuffer_Finish(ep->client_chanend, e, datalength);
 
         /* If error (e.g. bad PID seq) try again */
         if(result != XUD_RES_ERR)
@@ -211,7 +211,7 @@ void XUD_GetData_Select(chanend c, XUD_ep e, unsigned *datalength, XUD_Result_t 
 {
     volatile XUD_ep_info * ep = (XUD_ep_info*) e;
 
-    *result = XUD_GetBuffer_Finish(ep->client_chanend, ep, datalength);
+    *result = XUD_GetBuffer_Finish(ep->client_chanend, e, datalength);
 }
 
 XUD_Result_t XUD_GetSetupBuffer(XUD_ep e, unsigned char buffer[], unsigned *datalength)
@@ -345,7 +345,7 @@ XUD_Result_t XUD_SetBuffer(XUD_ep e, unsigned char buffer[], unsigned datalength
         return result;
     }
 
-    return XUD_SetBuffer_Finish(ep->client_chanend, ep);
+    return XUD_SetBuffer_Finish(ep->client_chanend, e);
 }
 
 void XUD_SetData_Select(chanend c, XUD_ep e, XUD_Result_t *result)


### PR DESCRIPTION
Part of [sw_xvf3800 issue 1044](https://github.com/xmos/sw_xvf3800/issues/1044).

This PR removes three warnings seen when building XVF3800.  All three warnings come from XUD_EpFunctions.c, and they all have the same message:

`incompatible pointer to integer conversion passing 'volatile XUD_ep_info *' (aka 'volatile struct XUD_ep_info *') to parameter of type 'XUD_ep' (aka 'unsigned int')`