### PR TITLE
rx_rise_delay set to 1 which fixes the MIDI test failure on XS2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ lib_xud Change Log
 UNRELEASED
 ----------
 
-  * CHANGE:   RX_RISE_DELAY for XS2 to fix MIDI test failures
+  * CHANGE:   RX_RISE_DELAY for XS2A based devices to resolve intermittent transmit timing issues
 
 2.3.1
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_xud Change Log
 ==================
 
+UNRELEASED
+----------
+
+  * CHANGE:   RX_RISE_DELAY for XS2 to fix MIDI test failures
+
 2.3.1
 -----
 

--- a/lib_xud/src/core/XUD_Main.xc
+++ b/lib_xud/src/core/XUD_Main.xc
@@ -1,4 +1,4 @@
-// Copyright 2011-2023 XMOS LIMITED.
+// Copyright 2011-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /**

--- a/lib_xud/src/core/XUD_Main.xc
+++ b/lib_xud/src/core/XUD_Main.xc
@@ -201,7 +201,7 @@ static int XUD_Manager_loop(XUD_chan epChans0[], XUD_chan epAddr_Ready[],  chane
         #endif
     #endif
 #else
-    #define RX_RISE_DELAY 5
+    #define RX_RISE_DELAY 1
     #define RX_FALL_DELAY 5
     #define TX_RISE_DELAY 5
     #define TX_FALL_DELAY 1


### PR DESCRIPTION
I've tested this across multiple nightly and one weekend runs and see no unexpected failures on XS2 tests. The MIDI tests which were failing with the original value of rx_rise_delay are also passing now on XS2.