### PR TITLE
Update JSL and Python

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.18.0') _
+@Library('xmos_jenkins_shared_library@v0.32.0') _
 
 getApproval()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ getApproval()
 
 pipeline {
   agent {
-    label 'x86_64 && macOS'
+    label 'x86_64 && linux'
   }
   environment {
     REPO = 'lib_xud'

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 XMOS LIMITED.
+# Copyright 2020-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import setuptools
 
@@ -13,9 +13,9 @@ setuptools.setup(
     name="lib_xud",
     packages=setuptools.find_packages(),
     install_requires=[
-        "black~=21.5b1",
-        "pytest~=6.2",
-        "pytest-xdist~=2.3",
+        "black",
+        "pytest",
+        "pytest-xdist",
     ],
     dependency_links=[],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# python_version 3.7.6
+# python_version 3.12
 #
 # The parse_version_from_requirements() function in the installPipfile.groovy
 # file of the Jenkins Shared Library uses the python_version comment to set

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@
 # pip-install this one as editable using this repository's setup.py file.  The
 # same modules should appear in the setup.py list as given below.
 
-black==21.5b1
-filelock==3.0.12
+black
+filelock
 pytest
 pytest-xdist
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@ black==21.5b1
 filelock==3.0.12
 # Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
 importlib-metadata==4.13.0
-pytest==6.2.4
-pytest-xdist==2.3.0
+pytest
+pytest-xdist
 filelock==3.0.12
 
 # Development dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,11 +19,8 @@
 
 black==21.5b1
 filelock==3.0.12
-# Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
-importlib-metadata==4.13.0
 pytest
 pytest-xdist
-filelock==3.0.12
 
 # Development dependencies
 #


### PR DESCRIPTION
Part of LSM-79
Fixes get-pip.py compatibility issue with Python 3.7