### PR TITLE
Remove flash info from .xn files

### DIFF
--- a/tests/shared/test_xs2.xn
+++ b/tests/shared/test_xs2.xn
@@ -56,7 +56,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>


### PR DESCRIPTION
From [LSM-101](https://xmosjira.atlassian.net/browse/LSM-101).

Since XTC 15.2.1, we use SFDP to get information about the flash chip on the board, so including this information in the `.xn` files is no longer necessary. This PR removes that information from those files so tools like `xflash` don't give warnings that this information is present.

[LSM-101]: https://xmosjira.atlassian.net/browse/LSM-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ