### PR TITLE
Adding MSOS 2.0 support to lib_xud

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 lib_xud change log
 ==================
 
+UNRELEASED
+----------
+
+  * ADDED: Support for Microsoft OS 2.0 descriptors
+  * CHANGED: Updated documentation
+
 4.0.0
 -----
 

--- a/doc/Doxyfile.inc
+++ b/doc/Doxyfile.inc
@@ -3,6 +3,6 @@
 PROJECT_NAME           = lib_xud
 PROJECT_BRIEF          = "USB device library"
 
-INPUT                  = ../lib_xud/api
+INPUT                  = ../lib_xud/api ../lib_xud/src/user/control/msos2
 
 PREDEFINED             = MA_C_API= C_API_START= C_API_END= __DOXYGEN__=1 ATTRIB_WEAK=

--- a/doc/rst/control_eps.rst
+++ b/doc/rst/control_eps.rst
@@ -133,6 +133,50 @@ The ``USB_StandardRequests()`` function handles the following Standard Endpoint 
 * ``CLEAR_FEATURE``
 * ``GET_STATUS``
 
+.. _sec_msos_support:
+
+MSOS 2.0 Support
+================
+
+``lib_xud`` provides support for the Microsoft OS 2.0 Descriptors (MSOS 2.0) specification. This allows for
+automatic driver installation on Windows hosts for devices that support this feature.
+
+.. note:: 
+   
+   MSOS 2.0 descriptors are only supported in C code, not XC. This is due to structure packing requirements.
+   The the following functions are available if the application Endpoint0 function is written in C.
+   However, XC applications can still make use of MSOS 2.0 descriptors by implementing the
+   a simple wrapper. See :c:func:`XUD_Init_Simple_Ep0_Msos_Descriptors` for more details.
+
+A detailed explanation of MSOS 2.0 descriptors is beyond the scope of this documentation.
+Please see the official Microsoft documentation for more details. Also, see the application note 
+`AN00136 Example USB Vendor Specific Device <https://www.xmos.com/file/an00136>`_ and the examples 
+in ``lib_xua`` for more details.
+
+The MSOS 2.0 descriptors are retrieved via requests over Endpoint0, and need some simple preparation before enumeration.
+
+.. doxygenfunction:: XUD_RegisterMsosDescriptors
+
+.. doxygenfunction:: XUD_Update_Guid_In_Msos_Desc
+
+.. doxygenfunction:: XUD_GetBosDescriptor
+
+.. doxygenfunction:: XUD_GetMsosDescriptor
+
+MSOS 2.0 Configuration
+----------------------
+
+There are defines provided to aid the construction and access to the MSOS 2.0 descriptors.
+
+See :c:macro:`XUD_WINUSB_DEVICE_INTERFACE_GUID_CONTROL` and :c:macro:`XUD_REQUEST_GET_MSOS_DESCRIPTOR` for more details.
+
+MSOS 2.0 Example Wrapper
+------------------------
+
+A simple example wrapper function is provided to aid XC applications in implementing MSOS 2.0 support.
+
+.. doxygenfunction:: XUD_Init_Simple_Ep0_Msos_Descriptors
+
 Control Endpoint Example
 ========================
 

--- a/doc/rst/options.rst
+++ b/doc/rst/options.rst
@@ -13,3 +13,6 @@ This section lists build time configuration defines that impact the behaviour of
 
 .. doxygendefine:: XUD_USB_ISO_EP_MAX_TXN_SIZE
 
+.. doxygendefine:: XUD_WINUSB_DEVICE_INTERFACE_GUID_CONTROL
+
+.. doxygendefine:: XUD_REQUEST_GET_MSOS_DESCRIPTOR

--- a/lib_xud/api/xud.h
+++ b/lib_xud/api/xud.h
@@ -166,13 +166,45 @@ typedef enum XUD_BusState_t
     XUD_BUS_KILL
 } XUD_BusState_t;
 
+/**
+ * @def XUD_OSC_MHZ
+ * @brief Frequency of oscillator used to clock xcore (in MHz)
+ */
 #ifndef XUD_OSC_MHZ
 #define XUD_OSC_MHZ                 (24)
 #endif
 
-/* Option to put the phy in low power mode during USB suspend */
+/**
+ * @def XUD_SUSPEND_PHY
+ * @brief Option to put the PHY in low power mode during USB suspend.
+ *
+ * When set to 1, the PHY will enter low power mode during USB suspend.
+ * When set to 0 (default), this feature is disabled.
+ *
+ * Only supported on XS3A/xcore.ai based devices.
+ */
 #ifndef XUD_SUSPEND_PHY
-#define XUD_SUSPEND_PHY             (1)
+#define XUD_SUSPEND_PHY             (0)
+#endif
+
+/**
+ * @brief Device interface GUID for the MSOS 2.0 Descriptor.
+ *
+ * This is provided as part of the device registry property in the MSOS 2.0 descriptor.
+ * Default: "{a008382b-5adc-464f-a849-17500f09074c}" User can override by defining their own in xud_conf.h
+ */
+#ifndef XUD_WINUSB_DEVICE_INTERFACE_GUID_CONTROL
+#define XUD_WINUSB_DEVICE_INTERFACE_GUID_CONTROL    "{a008382b-5adc-464f-a849-17500f09074c}"
+#endif
+
+/**
+ * @brief Request code for the D2H vendor request that the host will use to request the MSOS descriptor.
+ *
+ * The user shouldn't use this bRequest number in their custom vendor requests to the device, as it is now reserved for descriptor handling.
+ * However, the user can override this define to use a different bRequest number if required.
+ */
+#ifndef XUD_REQUEST_GET_MSOS_DESCRIPTOR
+#define XUD_REQUEST_GET_MSOS_DESCRIPTOR     0x20
 #endif
 
 /** This performs the low-level USB I/O operations. Note that this
@@ -478,27 +510,6 @@ void XUD_SetData_Select(chanend c, XUD_ep ep, REFERENCE_PARAM(XUD_Result_t, resu
 
 /* Control token defines - used to inform EPs of bus-state types */
 #define USB_RESET_TOKEN             (8)        /* Control token value that signals RESET */
-
-/**
- * @def XUD_OSC_MHZ
- * @brief Frequency of oscillator used to clock xcore (in MHz)
- */
-#ifndef XUD_OSC_MHZ
-#define XUD_OSC_MHZ                 (24)
-#endif
-
-/**
- * @def XUD_SUSPEND_PHY
- * @brief Option to put the PHY in low power mode during USB suspend.
- *
- * When set to 1, the PHY will enter low power mode during USB suspend.
- * When set to 0 (default), this feature is disabled.
- *
- * Only supported on XS3A/xcore.ai based devices.
- */
-#ifndef XUD_SUSPEND_PHY
-#define XUD_SUSPEND_PHY             (0)
-#endif
 
 /**
  * @def XUD_THREAD_MODE_FAST_EN

--- a/lib_xud/lib_build_info.cmake
+++ b/lib_xud/lib_build_info.cmake
@@ -1,6 +1,6 @@
 set(LIB_NAME lib_xud)
 set(LIB_VERSION 4.0.0)
-set(LIB_INCLUDES api src/user api/legacy src/core src/user/class)
+set(LIB_INCLUDES api src/user src/user/control/msos2 api/legacy src/core src/user/class)
 
 set(LIB_DEPENDENT_MODULES "")
 

--- a/lib_xud/module_build_info
+++ b/lib_xud/module_build_info
@@ -29,11 +29,13 @@ EXPORT_INCLUDE_DIRS = api \
 
 INCLUDE_DIRS = $(EXPORT_INCLUDE_DIRS) \
                src/core \
-               src/user/class
+               src/user/class \
+               src/user/control/msos2
 
 SOURCE_DIRS = src/core \
               src/user/client \
-              src/user/control
+              src/user/control \
+              src/user/control/msos2
 
 EXCLUDE_FILES += XUD_CrcAddrCheck.S \
                  XUD_PidJumpTable.S \

--- a/lib_xud/src/user/control/msos2/msos_descriptors.h
+++ b/lib_xud/src/user/control/msos2/msos_descriptors.h
@@ -1,0 +1,149 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/** MSOS 2.0 Descriptors
+*/
+
+#ifndef _MSOS_DESCRIPTORS_H_
+#define _MSOS_DESCRIPTORS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __XC__
+#error "mos_descriptors.h is not supported in XC, only C. Due to struct packing requirements."
+#endif
+
+#define PACKED_STRUCT __attribute__((packed))
+
+// total length, number of device caps
+#define _U16(_high, _low)   ((uint16_t) (((_high) << 8) | (_low)))
+#define _U16_HIGH(_u16)     ((uint8_t) (((_u16) >> 8) & 0x00ff))
+#define _U16_LOW(_u16)      ((uint8_t) ((_u16)       & 0x00ff))
+#define U16_TO_U8S_BE(_u16)   _U16_HIGH(_u16), _U16_LOW(_u16)
+#define U16_TO_U8S_LE(_u16)   _U16_LOW(_u16), _U16_HIGH(_u16)
+
+#define _U32_BYTE3(_u32)    ((uint8_t) ((((uint32_t) _u32) >> 24) & 0x000000ff)) // MSB
+#define _U32_BYTE2(_u32)    ((uint8_t) ((((uint32_t) _u32) >> 16) & 0x000000ff))
+#define _U32_BYTE1(_u32)    ((uint8_t) ((((uint32_t) _u32) >>  8) & 0x000000ff))
+#define _U32_BYTE0(_u32)    ((uint8_t) (((uint32_t)  _u32)        & 0x000000ff)) // LSB
+
+#define U32_TO_U8S_BE(_u32)   _U32_BYTE3(_u32), _U32_BYTE2(_u32), _U32_BYTE1(_u32), _U32_BYTE0(_u32)
+#define U32_TO_U8S_LE(_u32)   _U32_BYTE0(_u32), _U32_BYTE1(_u32), _U32_BYTE2(_u32), _U32_BYTE3(_u32)
+
+// BOS descriptor related defines
+#define USB_DESCTYPE_BOS                    (0x0F)
+#define USB_DESCTYPE_DEVICE_CAPABILITY      (0x10)
+#define DEVICE_CAPABILITY_PLATFORM          0x05
+#define USB_BOS_MS_OS_20_UUID               0xDF, 0x60, 0xDD, 0xD8, 0x89, 0x45, 0xC7, 0x4C, \
+                                            0x9C, 0xD2, 0x65, 0x9D, 0x9E, 0x64, 0x8A, 0x9F
+
+/** USB Binary Device Object Store (BOS) Descriptor */
+typedef struct {
+  uint8_t  bLength;         ///< Size of this descriptor in bytes
+  uint8_t  bDescriptorType; ///< BOS Descriptor Type
+  uint16_t wTotalLength;    ///< Total length of data returned for this descriptor
+  uint8_t  bNumDeviceCaps;  ///< Number of device capability descriptors in the BOS
+} PACKED_STRUCT USB_Descriptor_BOS_standard_t;
+
+// Platform device capability BOS descriptor
+// MSOS 2.0 platform capability
+typedef struct
+{
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint8_t bDevCapabilityType;
+  uint8_t bReserved;
+  uint8_t PlatformCapabilityUUID[16];
+  uint8_t CapabilityData[8]; // defined as Variable sized for the descriptor in general but 8 for us
+} PACKED_STRUCT USB_Descriptor_BOS_platform_t;
+
+typedef struct
+{
+  USB_Descriptor_BOS_standard_t usb_desc_bos_standard;
+  USB_Descriptor_BOS_platform_t usb_desc_bos_platform;
+} PACKED_STRUCT USB_Descriptor_BOS_t;
+
+// MSOS descriptor related defines
+#define MSOS_PROPERTY_NAME_LEN            (42) /* bytes */
+#define MSOS_INTERFACE_GUID_LEN           (80) /* bytes */
+/* x/2 to go from utf-16 to single byte characters that make up the GUID string, -2 to remove both null characters */
+#define DEVICE_INTERFACE_GUID_MAX_STRLEN  ((MSOS_INTERFACE_GUID_LEN / 2) - 2)
+
+// Microsoft OS 2.0 Descriptors, Table 8
+#define MS_OS_20_DESCRIPTOR_INDEX 7 /* wIndex of the D2H vendor request sent by the host to read the MSOS descriptor*/
+
+typedef enum
+{
+  MS_OS_20_SET_HEADER_DESCRIPTOR       = 0x00,
+  MS_OS_20_SUBSET_HEADER_CONFIGURATION = 0x01,
+  MS_OS_20_SUBSET_HEADER_FUNCTION      = 0x02,
+  MS_OS_20_FEATURE_COMPATIBLE_ID       = 0x03,
+  MS_OS_20_FEATURE_REG_PROPERTY        = 0x04,
+  MS_OS_20_FEATURE_MIN_RESUME_TIME     = 0x05,
+  MS_OS_20_FEATURE_MODEL_ID            = 0x06,
+  MS_OS_20_FEATURE_CCGP_DEVICE         = 0x07,
+  MS_OS_20_FEATURE_VENDOR_REVISION     = 0x08
+} microsoft_os_20_type_t;
+
+
+
+// USB MSOS2.0 Descriptors
+typedef struct {
+  uint16_t wLength;
+  uint16_t  wDescriptorType;
+  uint32_t dwWindowsVersion;
+  uint16_t  wTotalLength;
+} PACKED_STRUCT MSOS_desc_header_t;
+
+typedef struct {
+  uint16_t wLength;
+  uint16_t  wDescriptorType;
+  uint8_t bConfigurationValue;
+  uint8_t bReserved;
+  uint16_t wTotalLength;
+} PACKED_STRUCT MSOS_desc_cfg_subset_header_t;
+
+typedef struct {
+  uint16_t wLength;
+  uint16_t  wDescriptorType;
+  uint8_t bFirstInterface;
+  uint8_t bReserved;
+  uint16_t wSubsetLength;
+} PACKED_STRUCT MSOS_desc_fn_subset_header_t;
+
+typedef struct {
+  uint16_t wLength;
+  uint16_t  wDescriptorType;
+  uint8_t CompatibleID[8];
+  uint8_t SubCompatibleID[8];
+} PACKED_STRUCT MSOS_desc_compat_id_t;
+
+
+typedef struct
+{
+  uint16_t wLength;
+  uint16_t  wDescriptorType;
+  uint16_t wPropertyDataType;
+  uint16_t wPropertyNameLength;
+  uint8_t PropertyName[MSOS_PROPERTY_NAME_LEN];
+  uint16_t wPropertyDataLength;
+  // wchar_t PropertyData[MSOS_INTERFACE_GUID_WCHARS];
+  uint8_t PropertyData[MSOS_INTERFACE_GUID_LEN];
+} PACKED_STRUCT MSOS_desc_registry_property_t;
+
+
+// Registry property descriptor - wPropertyDataType
+typedef enum
+{
+    MSOS_REG_PROPERTY_DATA_TYPE_REG_RESERVED,
+    MSOS_REG_PROPERTY_DATA_TYPE_REG_SZ,
+    MSOS_REG_PROPERTY_DATA_TYPE_REG_EXPAND_SZ,
+    MSOS_REG_PROPERTY_DATA_TYPE_REG_BINARY,
+    MSOS_REG_PROPERTY_DATA_TYPE_REG_DWORD_LITTLE_ENDIAN,
+    MSOS_REG_PROPERTY_DATA_TYPE_REG_DWORD_BIG_ENDIAN,
+    MSOS_REG_PROPERTY_DATA_TYPE_REG_LINK,
+    MSOS_REG_PROPERTY_DATA_TYPE_REG_MULTI_SZ
+} msos_property_data_type_t;
+
+#endif // _MSOS_DESCRIPTORS_H_

--- a/lib_xud/src/user/control/msos2/msos_helpers.c
+++ b/lib_xud/src/user/control/msos2/msos_helpers.c
@@ -1,0 +1,70 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* MSOS 2.0 Descriptors for vendor Endpoint 0 handling */
+
+#include "msos_helpers.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "msos_descriptors.h"
+#include "xud_device.h"
+
+static desc_handle_t bos_handle = { NULL, 0, };
+
+static desc_handle_t msos_handle = { NULL, 0, };
+
+void XUD_RegisterMsosDescriptors(const desc_handle_t *bos_descs, const desc_handle_t *msos_descs)
+{
+    if (bos_descs != NULL) {
+        bos_handle.desc_ptr = bos_descs->desc_ptr;
+        bos_handle.desc_size = bos_descs->desc_size;
+    }
+
+    if (msos_descs != NULL) {
+        msos_handle.desc_ptr = msos_descs->desc_ptr;
+        msos_handle.desc_size = msos_descs->desc_size;
+    }
+}
+
+void XUD_Update_Guid_In_Msos_Desc(MSOS_desc_registry_property_t *registry, const char *guid_str)
+{
+    if (guid_str == NULL || registry == NULL) {
+        return;
+    }
+    unsigned char *msos_guid_ptr = registry->PropertyData;
+    size_t guid_len = strnlen(guid_str, DEVICE_INTERFACE_GUID_MAX_STRLEN + 1);
+
+    if (guid_len != DEVICE_INTERFACE_GUID_MAX_STRLEN) {
+        return;
+    }
+
+    // Convert char array to UTF-16LE
+    for(int i = 0; i < DEVICE_INTERFACE_GUID_MAX_STRLEN; i++)
+    {
+        msos_guid_ptr[2 * i] = guid_str[i];
+        msos_guid_ptr[(2 * i) + 1] = 0x0;
+    }
+}
+
+XUD_Result_t XUD_GetBosDescriptor(XUD_ep ep0_out, XUD_ep ep0_in, const USB_SetupPacket_t *sp)
+{
+    XUD_Result_t result = XUD_RES_ERR;
+
+    if ((bos_handle.desc_ptr != NULL) && ((sp->wValue & 0xff00) == (USB_DESCTYPE_BOS << 8))) {
+        result = XUD_DoGetRequest(ep0_out, ep0_in, bos_handle.desc_ptr, bos_handle.desc_size, sp->wLength);
+    }
+    return result;
+}
+
+XUD_Result_t XUD_GetMsosDescriptor(XUD_ep ep0_out, XUD_ep ep0_in, const USB_SetupPacket_t *sp)
+{
+    XUD_Result_t result = XUD_RES_ERR;
+
+    if ((msos_handle.desc_ptr != NULL) && (sp->wIndex == MS_OS_20_DESCRIPTOR_INDEX)) {
+        result = XUD_DoGetRequest(ep0_out, ep0_in, msos_handle.desc_ptr, msos_handle.desc_size, sp->wLength);
+    }
+    return result;
+}

--- a/lib_xud/src/user/control/msos2/msos_helpers.h
+++ b/lib_xud/src/user/control/msos2/msos_helpers.h
@@ -1,0 +1,94 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* MSOS 2.0 Descriptors for vendor Endpoint 0 handling */
+
+#ifndef _MSOS_HELPERS_H_
+#define _MSOS_HELPERS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "xud.h"
+#include "xud_device.h"
+
+#if defined(__XC__) || defined(__cplusplus)
+extern "C" {
+#endif
+
+#if !defined(__XC__)
+/* These types and functions are only available to C code. Due to struct packing requirements in the MSOS descriptors, they cannot be used in XC code.
+ * If the endpoint0 code is run in XC, then a small wrapper should be used to initialise the BOS and MSOS descriptors.
+ * For single interface example, see `simple_ep0_msos_descriptors.h` */
+
+#include "msos_descriptors.h"
+
+/** Descriptor handle
+ * 
+ * Used to pass descriptor pointer and size. As the type will change with different applications, as will the length.
+ * The USB driver will only want a byte array and length.
+ */
+typedef struct desc_handle_t
+{
+    unsigned char *desc_ptr;
+    size_t desc_size;
+} desc_handle_t;
+
+/** Register the application MSOS and BOS descriptors, before enumeration.
+ * 
+ * \param bos_descs    Pointer to the BOS descriptor handle
+ * \param msos_descs   Pointer to the MSOS descriptor handle
+ */
+void XUD_RegisterMsosDescriptors(const desc_handle_t *bos_descs, const desc_handle_t *msos_descs);
+
+/** Update the device interface GUID in the MSOS descriptor, before enumeration.
+ * 
+ * The device MSOS 2.0 GUID is used by the host to bind the correct driver to the device.
+ * The example GUID provided are intended to use with WINUSB driver on Windows.
+ * 
+ * When user's develop their own USB device, they should generate their own unique GUID for the device
+ * interface and link this to the host driver.
+ * 
+ * \param registry  Pointer to the registry property descriptor to update
+ * \param guid_str  String containing the device interface GUID for the control interface.
+ *                  Must be in the format "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}" and 
+ *                  DEVICE_INTERFACE_GUID_MAX_STRLEN long, plus null terminator.
+ */
+void XUD_Update_Guid_In_Msos_Desc(MSOS_desc_registry_property_t *registry, const char *guid_str);
+
+#endif
+
+/** Endpoint0 function to send the BOS descriptor when prompted via a Standard Get request
+ * 
+ * Request will be Standard Get request (USB_GET_DESCRIPTOR) with wValue high byte == USB_DESCTYPE_BOS
+ * 
+ * \param ep0_out   Endpoint 0 OUT endpoint
+ * \param ep0_in    Endpoint 0 IN endpoint
+ * \param sp        Pointer to the setup packet of the request
+ * 
+ * \retval          XUD_RES_ERR if request not handled
+ * \retval          XUD_RES_OKAY if successful
+ * \retval          XUD_RES_WAIT if transfer in progress
+ */
+XUD_Result_t XUD_GetBosDescriptor(XUD_ep ep0_out, XUD_ep ep0_in, const USB_SetupPacket_t *sp);
+
+/** Endpoint0 function to send the MSOS descriptor when prompted via a Vendor Get request
+ * 
+ * Request will be a Vendor Get request with bRequest == XUD_REQUEST_GET_MSOS_DESCRIPTOR.
+ * This is defined in xud.h
+ * 
+ * \param ep0_out   Endpoint 0 OUT endpoint
+ * \param ep0_in    Endpoint 0 IN endpoint
+ * \param sp        Pointer to the setup packet of the request
+ * 
+ * \retval          XUD_RES_ERR if request not handled
+ * \retval          XUD_RES_OKAY if successful
+ * \retval          XUD_RES_WAIT if transfer in progress
+ */
+XUD_Result_t XUD_GetMsosDescriptor(XUD_ep ep0_out, XUD_ep ep0_in, const USB_SetupPacket_t *sp);
+
+#if defined(__XC__) || defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif

--- a/lib_xud/src/user/control/msos2/simple_ep0_msos_descriptors.c
+++ b/lib_xud/src/user/control/msos2/simple_ep0_msos_descriptors.c
@@ -1,0 +1,96 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* MSOS 2.0 Descriptors for vendor Endpoint 0 handling */
+
+#include "simple_ep0_msos_descriptors.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <wchar.h>
+
+#include "msos_descriptors.h"
+#include "msos_helpers.h"
+#include "xud.h"
+
+/** Example of simple, single interface, MSOS 2.0 descriptor
+ * 
+ * For more complex examples, see lib_xua DFU and Control in xua_ep0_msos_descriptors.h
+ */
+typedef struct {
+  MSOS_desc_header_t              msos_desc_header;
+  MSOS_desc_compat_id_t           msos_desc_compat_id;
+  MSOS_desc_registry_property_t   msos_desc_registry_property;
+} __attribute__((packed)) MSOS_desc_simple_t;
+
+/* USB Binary Device Object Store (BOS) descriptor */
+static USB_Descriptor_BOS_t desc_bos_control =
+{
+    .usb_desc_bos_standard = {
+        .bLength = sizeof(USB_Descriptor_BOS_standard_t),
+        .bDescriptorType = USB_DESCTYPE_BOS,
+        .wTotalLength = sizeof(USB_Descriptor_BOS_standard_t) + sizeof(USB_Descriptor_BOS_platform_t),
+        .bNumDeviceCaps = 1
+    },
+    .usb_desc_bos_platform = {
+        .bLength = sizeof(USB_Descriptor_BOS_platform_t),
+        .bDescriptorType = USB_DESCTYPE_DEVICE_CAPABILITY,
+        .bDevCapabilityType = DEVICE_CAPABILITY_PLATFORM,
+        .bReserved = 0,
+        .PlatformCapabilityUUID = {USB_BOS_MS_OS_20_UUID},
+        .CapabilityData = {U32_TO_U8S_LE(0x06030000), U16_TO_U8S_LE(sizeof(MSOS_desc_simple_t)), XUD_REQUEST_GET_MSOS_DESCRIPTOR, 0}
+    }
+};
+
+/* USB MSOS 2.0 descriptor */
+static MSOS_desc_simple_t desc_ms_os_20_simple =
+{
+    .msos_desc_header =
+    {
+        .wLength = sizeof(MSOS_desc_header_t),
+        .wDescriptorType = MS_OS_20_SET_HEADER_DESCRIPTOR,
+        .dwWindowsVersion = 0x06030000, // 0603 == Windows 8.1
+        .wTotalLength = sizeof(MSOS_desc_simple_t)
+    },
+    .msos_desc_compat_id =
+    {
+        .wLength = sizeof(MSOS_desc_compat_id_t),
+        .wDescriptorType = MS_OS_20_FEATURE_COMPATIBLE_ID,
+        .CompatibleID = {'W', 'I', 'N', 'U', 'S', 'B', 0x00, 0x00},
+        .SubCompatibleID = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+    },
+    .msos_desc_registry_property =
+    {
+        .wLength = sizeof(MSOS_desc_registry_property_t),
+        .wDescriptorType = MS_OS_20_FEATURE_REG_PROPERTY,
+        .wPropertyDataType = MSOS_REG_PROPERTY_DATA_TYPE_REG_MULTI_SZ,
+        .wPropertyNameLength = MSOS_PROPERTY_NAME_LEN,
+        .PropertyName = {'D', 0x00, 'e', 0x00, 'v', 0x00, 'i', 0x00, 'c', 0x00, 'e', 0x00, 'I', 0x00, 'n', 0x00, 't', 0x00, 'e', 0x00,
+                         'r', 0x00, 'f', 0x00, 'a', 0x00, 'c', 0x00, 'e', 0x00, 'G', 0x00, 'U', 0x00, 'I', 0x00, 'D', 0x00, 's', 0x00, 0x00, 0x00}, //"DeviceInterfaceGUIDs\0" in UTF-16
+        .wPropertyDataLength = MSOS_INTERFACE_GUID_LEN,
+        // "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}\0\0" generate from https://guidgenerator.com/ and stored as Unicode
+        .PropertyData = { 0 } // defined in the XUD_WINUSB_DEVICE_INTERFACE_GUID_CONTROL define and updated in the descriptor at runtime with update_guid_in_msos_desc()
+    }
+};
+
+
+/* Device Interface GUID */
+static char g_device_interface_guid_control_str[DEVICE_INTERFACE_GUID_MAX_STRLEN + 1] = XUD_WINUSB_DEVICE_INTERFACE_GUID_CONTROL;
+
+void XUD_Init_Simple_Ep0_Msos_Descriptors(void)
+{
+    // Apply valid GUID
+    if (strnlen(g_device_interface_guid_control_str, (DEVICE_INTERFACE_GUID_MAX_STRLEN + 1)) == DEVICE_INTERFACE_GUID_MAX_STRLEN) {
+        XUD_Update_Guid_In_Msos_Desc(&desc_ms_os_20_simple.msos_desc_registry_property, g_device_interface_guid_control_str);
+    }
+
+    desc_handle_t bos_handle = {
+        (unsigned char*)&desc_bos_control, sizeof(USB_Descriptor_BOS_t),
+    };
+
+    desc_handle_t msos_handle = {
+        (unsigned char*)&desc_ms_os_20_simple, sizeof(MSOS_desc_simple_t),
+    };
+    XUD_RegisterMsosDescriptors(&bos_handle, &msos_handle);
+}

--- a/lib_xud/src/user/control/msos2/simple_ep0_msos_descriptors.h
+++ b/lib_xud/src/user/control/msos2/simple_ep0_msos_descriptors.h
@@ -1,0 +1,31 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* MSOS 2.0 Descriptors for vendor Endpoint 0 handling */
+
+#ifndef _SIMPLE_EP0_MSOS_DESCRIPTORS_H_
+#define _SIMPLE_EP0_MSOS_DESCRIPTORS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "xud.h"
+#include "xud_device.h"
+
+/* Example of simple, single interface, MSOS 2.0 descriptor
+ * 
+ * For more complex examples, see lib_xua DFU and Control in xua_ep0_msos_descriptors.h
+ */
+
+#if defined(__XC__) || defined(__cplusplus)
+extern "C" {
+#endif
+
+/** Initialise the Simple Ep0 MSOS Descriptors before enumeration of the device */
+void XUD_Init_Simple_Ep0_Msos_Descriptors(void);
+
+#if defined(__XC__) || defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif


### PR DESCRIPTION
Adding MSOS 2.0 support to lib_xud porting from lib_xua.
* Adds MSOS 2.0 descriptor declarations,
* Adds descriptor definitions, for simple (single interface) use-case,
* Adds helper functions, 
* Adds to xud_conf, GUID for control/single interface case, and Vendor request value for fetching MSOS2 descs,

Note: the MSOS decriptors only work in C code due to struct packing requirements, there is a `#error` to catch if included directly into XC. Examples below show both C and XC usage (with wrapper).

Currently testing with,
* https://github.com/humphrey-xmos/an00136/tree/feature/update-msos-with-lib_xud,
* https://github.com/humphrey-xmos/lib_device_control/tree/feature/moving-msos-to-lib_xud
* https://github.com/humphrey-xmos/lib_xua/tree/feature/xud-msos-updates